### PR TITLE
Replace deprecated json_array with json

### DIFF
--- a/SettingsBundle/Entity/SettingValue.php
+++ b/SettingsBundle/Entity/SettingValue.php
@@ -79,7 +79,7 @@ class SettingValue extends AttributeValue
     /**
      * @var array
      *
-     * @ORM\Column(name="val_json", type="json_array", nullable=true)
+     * @ORM\Column(name="val_json", type="json", nullable=true)
      */
     protected $json;
 


### PR DESCRIPTION
See https://www.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/types.html#json-array. This caused `Unknown column type "json_array" requested` errors from doctrine after `composer update`